### PR TITLE
Adding robotester support for Solaris11

### DIFF
--- a/src/molecule_robotframework/playbooks/roles/robotframework/tasks/main.yml
+++ b/src/molecule_robotframework/playbooks/roles/robotframework/tasks/main.yml
@@ -38,6 +38,7 @@
       # Install pyyaml so `robot` will support yaml format variable files.
       - "pyyaml{{ pyyaml_version | d('') }}"
       - "{{ robotframework_package_name }}{{ robotframework_package_version_spec }}"
+    executable: "{{ pip_executable | d('pip3') }}"
   when: _robotframework_install
 
 - name: Install Robot Framework Test Libraries.
@@ -45,6 +46,7 @@
   pip:
     state: present
     name: "{{ robotframework_external_libraries }}"
+    executable: "{{ pip_executable | d('pip3') }}"
   when:
     - _robotframework_install
     - robotframework_external_libraries | count > 0

--- a/src/molecule_robotframework/playbooks/roles/robotframework/tasks/pip/CentOS-7.yml
+++ b/src/molecule_robotframework/playbooks/roles/robotframework/tasks/pip/CentOS-7.yml
@@ -14,3 +14,4 @@
 - name: Set package versions.
   set_fact:
     pyyaml_version: "<6"
+    pip_executable: "pip"

--- a/src/molecule_robotframework/playbooks/roles/robotframework/tasks/pip/Solaris-11.yml
+++ b/src/molecule_robotframework/playbooks/roles/robotframework/tasks/pip/Solaris-11.yml
@@ -1,0 +1,9 @@
+---
+- name: Ensure python pip is installed.
+  become: yes
+  pkg5:
+     state: present
+     name: pip-35
+- name: Set package versions and pip executable.
+  set_fact:
+    pip_executable: "pip-3.5"


### PR DESCRIPTION
Some tweaks were needed.
Timestamp rollover test failed on Solaris11 with python2:
OverflowError: Python int too large to convert to C long

Setting explicitly pip executable to pip-3.5 (no pip3 link on Solaris)
with a variable fix this. Then python3 is used to install the needed
modules. This variable needs to be set to pip for centos-7.
For all other platforms the executable: parameter is set to pip3.